### PR TITLE
Prevent command.log from being appended to when run in a loop (#501)

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,9 @@
+# Safety Security and License Configuration file
+# We recommend checking this file into your source control in the root of your Python project
+# If this file is named .safety-policy.yml and is in the same directory where you run `safety check` it will be used by default.
+# Otherwise, you can use the flag `safety check --policy-file <path-to-this-file>` to specify a custom location and name for the file.
+# To validate and review your policy file, run the validate command: `safety validate policy_file --path <path-to-this-file>`
+security: # configuration for the `safety check` command
+    ignore-vulnerabilities: # Here you can list multiple specific vulnerabilities you want to ignore (optionally for a time period)
+        67599: # Example vulnerability ID
+            reason: disputed, inapplicable

--- a/mvt/common/command.py
+++ b/mvt/common/command.py
@@ -85,6 +85,15 @@ class Command:
         )
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(formatter)
+
+        # MVT can be run in a loop
+        # Old file handlers stick around in subsequent loops
+        # Remove any existing logging.FileHandler instances
+        for handler in logger.handlers:
+            if isinstance(handler, logging.FileHandler):
+                logger.removeHandler(handler)
+
+        # And finally add the new one
         logger.addHandler(file_handler)
 
     def _store_timeline(self) -> None:


### PR DESCRIPTION
* Prevent command.log from being appended to when run in a loop

* Ignore a rather stupid vulnerability scan alert for pip